### PR TITLE
base: Fix margin layouts params of MobileNetworkTile

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/quicksettings/MobileNetworkTile.java
+++ b/packages/SystemUI/src/com/android/systemui/quicksettings/MobileNetworkTile.java
@@ -22,8 +22,8 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.view.View;
+import android.view.ViewGroup.MarginLayoutParams;
 import android.widget.ImageView;
-import android.widget.TextView;
 
 import com.android.internal.util.cm.QSUtils;
 import com.android.systemui.R;
@@ -166,5 +166,17 @@ public class MobileNetworkTile extends NetworkTile {
             return aux.substring(0, aux.length() - 1);
         }
         return aux;
+    }
+
+    // MobileNetworkTile use an internal frame, so we need to restrict frame margins
+    // instead of image margin
+    @Override
+    public void setImageMargins(int margin) {
+        View image = mTile.findViewById(R.id.image);
+        if (image != null) {
+            MarginLayoutParams params = (MarginLayoutParams) image.getLayoutParams();
+            params.topMargin = params.bottomMargin = margin;
+            image.setLayoutParams(params);
+        }
     }
 }


### PR DESCRIPTION
MobileNetworkTile use an internal frame, so we need to restrict frame margins instead of image margin

Change-Id: I1861866c814eece7911f6fc4a5671575173c12e0
Signed-off-by: Jorge Ruesga jorge@ruesga.com
